### PR TITLE
Add utf8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+termbox.so
+termbox.import.so
+termbox.import.scm

--- a/termbox.meta
+++ b/termbox.meta
@@ -4,5 +4,6 @@
 (synopsis "Library for writing text-based user interfaces")
 (license "BSD")
 (category ui)
+(needs utf8)
 
 )

--- a/termbox.scm
+++ b/termbox.scm
@@ -125,6 +125,7 @@ SOFTWARE.
 	 poll)
 	(import chicken scheme foreign)
 	(use srfi-4 extras)
+    (require-extension utf8)
 	
 #>
 #include "termbox.h"


### PR DESCRIPTION
By simply loading the utf8 egg, termbox now supports utf-8.

The problem stemmed from the calls to (string-length) and
(string->list) inside (create-cell) and (utf8-char-to-unicode) not
being utf8 aware by default.

![screen shot 2015-11-08 at 3 06 49 pm](https://cloud.githubusercontent.com/assets/1158933/11022357/99bc888e-862a-11e5-93b7-b3d00497b3bd.png)
